### PR TITLE
Add basic ChatGPT-powered DND engine skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# TheronAI DND Engine
+
+This repository contains a minimal skeleton for a ChatGPT-powered Dungeons & Dragons game engine written in Python. The project is intentionally light-weight and is meant as a starting point for further development.
+
+## Features
+
+- **Inventory system** – classes for items and managing player inventory
+- **Stat tracker** – representation of common DND attributes
+- **Character model** – combines stats and inventory
+- **ChatGPT integration** – communicate with OpenAI's API and parse JSON replies
+
+## Usage
+
+1. Install dependencies (mainly `openai`):
+   ```bash
+   pip install openai
+   ```
+2. Set your OpenAI API key when constructing `GameEngine` or via the `OPENAI_API_KEY` environment variable.
+3. Run the example:
+   ```bash
+   python main.py
+   ```
+   The engine attempts to contact ChatGPT. Without an API key or network access it will fail gracefully.
+
+This is only a starting point; feel free to expand the mechanics, add combat logic, or build a full campaign framework on top of it.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,10 @@
+"""TheronAI DND Engine package."""
+
+__all__ = ["inventory", "stats", "character", "game"]
+
+from .inventory import InventoryItem, Inventory
+from .stats import Stats
+from .character import Character
+from .game import GameEngine
+
+__version__ = "0.1.0"

--- a/engine/character.py
+++ b/engine/character.py
@@ -1,0 +1,35 @@
+"""Character representation for the DND engine."""
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from .inventory import Inventory, InventoryItem
+from .stats import Stats
+
+
+@dataclass
+class Character:
+    """Represents a player or NPC character."""
+
+    name: str
+    race: str = "Human"
+    char_class: str = "Fighter"
+    level: int = 1
+    stats: Stats = field(default_factory=Stats)
+    inventory: Inventory = field(default_factory=Inventory)
+
+    def add_item(self, item: InventoryItem) -> None:
+        self.inventory.add_item(item)
+
+    def remove_item(self, item_name: str) -> None:
+        self.inventory.remove_item(item_name)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "race": self.race,
+            "class": self.char_class,
+            "level": self.level,
+            "stats": self.stats.to_dict(),
+            "inventory": self.inventory.to_dict(),
+        }

--- a/engine/game.py
+++ b/engine/game.py
@@ -1,0 +1,43 @@
+"""Core game engine that interacts with ChatGPT."""
+
+import json
+from typing import Any, Dict, List
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai might not be installed in all envs
+    openai = None
+
+from .character import Character
+
+
+class GameEngine:
+    """Simple game engine using ChatGPT for narrative generation."""
+
+    def __init__(self, character: Character, openai_api_key: str = "") -> None:
+        self.character = character
+        self.api_key = openai_api_key
+        if openai and self.api_key:
+            openai.api_key = self.api_key
+
+    def chat_with_gpt(self, messages: List[Dict[str, str]]) -> str:
+        """Call the ChatGPT API with the provided messages."""
+        if not openai:
+            raise RuntimeError("openai package is required for API calls")
+        response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+        return response["choices"][0]["message"]["content"]
+
+    def request_action(self, prompt: str) -> Dict[str, Any]:
+        """Send a prompt to ChatGPT and expect a JSON response."""
+        system = {"role": "system", "content": "You are a DND game master."}
+        user = {"role": "user", "content": prompt}
+        content = self.chat_with_gpt([system, user])
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return {"error": "Invalid JSON", "content": content}
+
+    def run_turn(self, prompt: str) -> Dict[str, Any]:
+        """Example method for running a single turn using ChatGPT."""
+        action = self.request_action(prompt)
+        return action

--- a/engine/inventory.py
+++ b/engine/inventory.py
@@ -1,0 +1,37 @@
+"""Inventory system for the DND engine."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class InventoryItem:
+    """Represents a single item in an inventory."""
+
+    name: str
+    quantity: int = 1
+    description: str = ""
+
+    def to_dict(self) -> Dict[str, str]:
+        """Return a JSON-serializable representation of this item."""
+        return {
+            "name": self.name,
+            "quantity": self.quantity,
+            "description": self.description,
+        }
+
+
+@dataclass
+class Inventory:
+    """Container for inventory items."""
+
+    items: List[InventoryItem] = field(default_factory=list)
+
+    def add_item(self, item: InventoryItem) -> None:
+        self.items.append(item)
+
+    def remove_item(self, item_name: str) -> None:
+        self.items = [i for i in self.items if i.name != item_name]
+
+    def to_dict(self) -> Dict[str, List[Dict[str, str]]]:
+        return {"items": [item.to_dict() for item in self.items]}

--- a/engine/stats.py
+++ b/engine/stats.py
@@ -1,0 +1,33 @@
+"""Character statistics and utilities."""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Stats:
+    """Represents standard DND statistics."""
+
+    strength: int = 10
+    dexterity: int = 10
+    constitution: int = 10
+    intelligence: int = 10
+    wisdom: int = 10
+    charisma: int = 10
+    health: int = 10
+
+    def to_dict(self) -> Dict[str, int]:
+        return {
+            "strength": self.strength,
+            "dexterity": self.dexterity,
+            "constitution": self.constitution,
+            "intelligence": self.intelligence,
+            "wisdom": self.wisdom,
+            "charisma": self.charisma,
+            "health": self.health,
+        }
+
+    def modify(self, **kwargs: int) -> None:
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                setattr(self, key, getattr(self, key) + int(value))

--- a/main.py
+++ b/main.py
@@ -1,1 +1,21 @@
-#main.py
+"""Entry point for the TheronAI DND engine demo."""
+
+from engine import Character, InventoryItem, GameEngine
+
+
+def main() -> None:
+    hero = Character(name="Theron")
+    hero.add_item(InventoryItem(name="Sword", quantity=1, description="A sharp blade"))
+    engine = GameEngine(hero)
+
+    # Example prompt to start the game
+    prompt = "The hero enters a dark dungeon. Respond with JSON describing the scene."
+    try:
+        response = engine.run_turn(prompt)
+        print(response)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to contact ChatGPT: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README with usage notes
- create `engine` package with inventory, stats, character, and game engine modules
- expand `main.py` to demonstrate creating a character and running a turn

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845e78a509883228dfe3d3977d60d71