### PR TITLE
Add leveling and Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This repository contains a minimal skeleton for a ChatGPT-powered Dungeons & Dra
 - **Stat tracker** – representation of common DND attributes
 - **Character model** – combines stats and inventory
 - **ChatGPT integration** – communicate with OpenAI's API and parse JSON replies
+- **Dice rolling** – helper to roll dice with ``XdY`` notation
+- **Game state persistence** – save and load characters from JSON
+- **Basic combat** – simple attack resolution using dice rolls
+- **Leveling system** – gain experience and automatically level up
+- **Discord bot** – optional interface to play via a Discord server
 
 ## Usage
 
@@ -21,5 +26,49 @@ This repository contains a minimal skeleton for a ChatGPT-powered Dungeons & Dra
    python main.py
    ```
    The engine attempts to contact ChatGPT. Without an API key or network access it will fail gracefully.
+
+### Running the Discord bot
+
+Install the optional ``discord.py`` dependency:
+
+```bash
+pip install discord.py
+```
+
+Provide a ``DISCORD_BOT_TOKEN`` environment variable and run:
+
+```bash
+python discord_bot.py
+```
+
+## Saving and Loading Characters
+
+Use ``save_character`` and ``load_character`` to persist your hero between sessions:
+
+```python
+from engine import save_character, load_character
+
+save_character(hero, "hero.json")
+reloaded = load_character("hero.json")
+```
+
+## Rolling Dice
+
+The ``roll_dice`` helper parses standard notation:
+
+```python
+from engine import roll_dice
+damage = roll_dice("2d6+1")
+```
+
+## Leveling and Experience
+
+Characters gain experience through ``gain_experience``. When enough is
+accumulated (``100 * current level`` by default) they automatically level up
+and gain additional health.
+
+```python
+hero.gain_experience(150)  # levels to 2 and keeps leftover XP
+```
 
 This is only a starting point; feel free to expand the mechanics, add combat logic, or build a full campaign framework on top of it.

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,0 +1,46 @@
+"""Example Discord bot interface for the TheronAI engine."""
+
+import os
+
+import discord
+from discord.ext import commands
+
+from engine import Character, GameEngine, attack, roll_dice
+
+
+def create_bot(token: str) -> commands.Bot:
+    bot = commands.Bot(command_prefix="!")
+
+    hero = Character(name="Hero")
+    engine = GameEngine(hero)
+
+    @bot.command()
+    async def roll(ctx, notation: str):
+        try:
+            result = roll_dice(notation)
+            await ctx.send(f"Rolled {notation}: {result}")
+        except ValueError as exc:
+            await ctx.send(str(exc))
+
+    @bot.command()
+    async def attack_cmd(ctx):
+        goblin = Character(name="Goblin", stats=hero.stats.__class__(health=5))
+        result = attack(hero, goblin)
+        await ctx.send(f"Attack result: {result}")
+
+    @bot.command()
+    async def scene(ctx, *, prompt: str):
+        try:
+            response = engine.run_turn(prompt)
+            await ctx.send(str(response))
+        except Exception as exc:  # pragma: no cover - network call
+            await ctx.send(f"Error: {exc}")
+
+    return bot
+
+
+if __name__ == "__main__":
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_BOT_TOKEN environment variable not set")
+    create_bot(token).run(token)

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,10 +1,21 @@
 """TheronAI DND Engine package."""
 
-__all__ = ["inventory", "stats", "character", "game"]
+__all__ = [
+    "inventory",
+    "stats",
+    "character",
+    "game",
+    "dice",
+    "state",
+    "combat",
+]
 
 from .inventory import InventoryItem, Inventory
 from .stats import Stats
 from .character import Character
 from .game import GameEngine
+from .dice import roll_dice
+from .state import save_character, load_character
+from .combat import attack
 
 __version__ = "0.1.0"

--- a/engine/character.py
+++ b/engine/character.py
@@ -15,8 +15,24 @@ class Character:
     race: str = "Human"
     char_class: str = "Fighter"
     level: int = 1
+    experience: int = 0
     stats: Stats = field(default_factory=Stats)
     inventory: Inventory = field(default_factory=Inventory)
+
+    def gain_experience(self, amount: int) -> bool:
+        """Add experience and level up when thresholds are reached."""
+        self.experience += int(amount)
+        leveled = False
+        while self.experience >= self.level * 100:
+            self.experience -= self.level * 100
+            self.level_up()
+            leveled = True
+        return leveled
+
+    def level_up(self) -> None:
+        """Increase level and improve basic stats."""
+        self.level += 1
+        self.stats.modify(health=5)
 
     def add_item(self, item: InventoryItem) -> None:
         self.inventory.add_item(item)
@@ -30,6 +46,7 @@ class Character:
             "race": self.race,
             "class": self.char_class,
             "level": self.level,
+            "experience": self.experience,
             "stats": self.stats.to_dict(),
             "inventory": self.inventory.to_dict(),
         }

--- a/engine/combat.py
+++ b/engine/combat.py
@@ -1,0 +1,34 @@
+"""Simple turn-based combat utilities."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .character import Character
+from .dice import roll_dice
+
+
+def attack(attacker: Character, defender: Character, damage_die: str = "1d6") -> Dict[str, int | bool]:
+    """Resolve an attack from ``attacker`` against ``defender``.
+
+    Attack roll is ``1d20 + strength`` versus ``10 + dexterity``. On hit,
+    damage is rolled using ``damage_die`` and subtracted from defender's health.
+    """
+
+    attack_roll = roll_dice("1d20") + attacker.stats.strength
+    defense = 10 + defender.stats.dexterity
+    hit = attack_roll >= defense
+    damage = roll_dice(damage_die) if hit else 0
+    if hit:
+        defender.stats.modify(health=-damage)
+
+    return {
+        "hit": hit,
+        "attack_roll": attack_roll,
+        "defense": defense,
+        "damage": damage,
+        "defender_health": defender.stats.health,
+    }
+
+
+__all__ = ["attack"]

--- a/engine/dice.py
+++ b/engine/dice.py
@@ -1,0 +1,37 @@
+"""Utility functions for rolling dice using standard DND notation."""
+
+from __future__ import annotations
+
+import random
+import re
+
+_DICE_RE = re.compile(r"(?P<num>\d*)d(?P<sides>\d+)(?P<bonus>[+-]\d+)?")
+
+
+def roll_dice(notation: str) -> int:
+    """Roll dice based on a notation string like ``'2d6+1'``.
+
+    Parameters
+    ----------
+    notation:
+        Dice notation in the form ``XdY`` or ``XdY+Z``.
+
+    Returns
+    -------
+    int
+        The result of the roll.
+    """
+
+    match = _DICE_RE.fullmatch(notation.replace(" ", ""))
+    if not match:
+        raise ValueError(f"Invalid dice notation: {notation}")
+
+    num = int(match.group("num") or 1)
+    sides = int(match.group("sides"))
+    bonus = int(match.group("bonus") or 0)
+
+    total = sum(random.randint(1, sides) for _ in range(num)) + bonus
+    return total
+
+
+__all__ = ["roll_dice"]

--- a/engine/state.py
+++ b/engine/state.py
@@ -1,0 +1,45 @@
+"""Persistence helpers for saving and loading game state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .character import Character, InventoryItem, Stats
+
+
+def save_character(character: Character, path: str | Path) -> None:
+    """Save a :class:`Character` to ``path`` in JSON format."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(character.to_dict(), fh, indent=2)
+
+
+def load_character(path: str | Path) -> Character:
+    """Load a :class:`Character` from a JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    char = Character(
+        name=data.get("name", "Hero"),
+        race=data.get("race", "Human"),
+        char_class=data.get("class", "Fighter"),
+        level=data.get("level", 1),
+        experience=data.get("experience", 0),
+    )
+
+    stats_data = data.get("stats", {})
+    char.stats = Stats(**{k: int(v) for k, v in stats_data.items()})
+
+    inv_items = data.get("inventory", {}).get("items", [])
+    for item in inv_items:
+        char.add_item(
+            InventoryItem(
+                name=item.get("name", ""),
+                quantity=int(item.get("quantity", 1)),
+                description=item.get("description", ""),
+            )
+        )
+    return char
+
+
+__all__ = ["save_character", "load_character"]

--- a/main.py
+++ b/main.py
@@ -1,12 +1,32 @@
 """Entry point for the TheronAI DND engine demo."""
 
-from engine import Character, InventoryItem, GameEngine
+from engine import (
+    Character,
+    InventoryItem,
+    GameEngine,
+    roll_dice,
+    save_character,
+    load_character,
+    attack,
+)
 
 
 def main() -> None:
     hero = Character(name="Theron")
     hero.add_item(InventoryItem(name="Sword", quantity=1, description="A sharp blade"))
     engine = GameEngine(hero)
+
+    # Demonstrate dice rolling
+    print(f"Rolling 2d6+1 for attack damage: {roll_dice('2d6+1')}")
+
+    # Persist and reload the character
+    save_character(hero, "hero.json")
+    hero = load_character("hero.json")
+
+    # Example combat round
+    goblin = Character(name="Goblin", stats=hero.stats.__class__(health=5))
+    result = attack(hero, goblin)
+    print(f"Attack result: {result}")
 
     # Example prompt to start the game
     prompt = "The hero enters a dark dungeon. Respond with JSON describing the scene."

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from engine import Character, attack
+
+
+def test_attack_damage():
+    attacker = Character(name="Attacker")
+    defender = Character(name="Defender", stats=attacker.stats.__class__(health=10))
+    result = attack(attacker, defender, damage_die="1d4")
+    # After attack, defender health should not be greater than starting health
+    assert result["defender_health"] <= 10
+    assert result["defender_health"] >= 0

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from engine.dice import roll_dice
+
+
+def test_roll_dice_range():
+    result = roll_dice("2d6")
+    assert 2 <= result <= 12

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from engine import Character
+
+
+def test_gain_experience_level_up():
+    hero = Character(name="Hero")
+    leveled = hero.gain_experience(150)
+    assert hero.level == 2
+    assert hero.experience == 50
+    assert leveled

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from engine import Character, save_character, load_character
+
+
+def test_save_and_load(tmp_path):
+    hero = Character(name="TestHero")
+    path = tmp_path / "hero.json"
+    save_character(hero, path)
+    loaded = load_character(path)
+    assert loaded.name == hero.name


### PR DESCRIPTION
## Summary
- extend `Character` with experience and leveling mechanics
- persist experience in `load_character`
- provide Discord bot interface
- document new features and usage
- test leveling behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e8ff124c8322a9220e48b384f0c7